### PR TITLE
:arrow_up: omnisharp-client 7.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "atom-languageclient": "^0.6.1",
-    "omnisharp-client": "^7.1.3"
+    "omnisharp-client": "^7.2.1"
   },
   "enhancedScopes": [
     "source.cs"


### PR DESCRIPTION
This change updates omnisharp-client to 7.2.1 to take a new fix to
their server script which causes a bundled Mono 5.2 to be used on
macOS and Linux.  This resolves issue #7 where OmniSharp does not
start up on Linux when an older Mono version is installed.  The
minimum supported Mono version for OmniSharp is 5.2.